### PR TITLE
Gatsby Page Progress Plugin Now Working

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -31,15 +31,14 @@ module.exports = {
     `gatsby-plugin-percy`,
     `gatsby-plugin-sharp`,
     {
-    	resolve: `gatsby-plugin-page-progress`,
-    	options: {
-    		includePaths: ["/", { regex: "^/blog" }],
-      		excludePaths: [],
-      		height: 3,
-      		prependToBody: false,
-      		color: `#64ffda`,
-      		footerHeight: 500,
-    	},
+      resolve: `gatsby-plugin-page-progress`,
+      options: {
+        includePaths: ["/", { regex: "^/blog" }],
+        excludePaths: [],
+        height: 3,
+        prependToBody: false,
+        color: `#64ffda`,
+      },
     },
     {
       resolve: `gatsby-plugin-manifest`,


### PR DESCRIPTION
## Issue that this pull request solves

 Closes: #11  (issue number)

## Changes made

The width of the progress bar will be scaled appropriately to reach 100% before reaching the page footer. Having a large `footerHeight` will make the page always reach the end. Using the default value of 0 solves the bug.

Ref: https://www.gatsbyjs.org/packages/gatsby-plugin-page-progress/#footerheight

## Types of changes

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Documentation update (Documentation content changed).
- [ ] Other (please describe).

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project.
- [ ] I have made corresponding changes to the documentation.

## Screenshots

![Peek 2020-06-29 13-49](https://user-images.githubusercontent.com/39518771/85990337-7b0dd000-ba0f-11ea-8263-f0007157d315.gif)